### PR TITLE
Extension urls

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -35,7 +35,7 @@ EM_Quickshop,,/quickshop/index/view/,https://magento.com/security/vulnerabilitie
 FME_Jobs,,,Ryan Hoerr,https://www.fmeextensions.com/magento-open-jobs-manager.html
 FME_Productattachments,2.5.3,productattachments/index/download,https://twitter.com/stevemarkperry/status/1067783411039911937,https://www.fmeextensions.com/magento-product-attachments-file-uploads-extension.html
 Fooman_TcpdfLib,6.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser
-HE_TwoFactorAuth,2018-10-18,,,https://github.com/nexcess/magento-sentry-two-factor-authentication
+HE_TwoFactorAuth,2018-10-18,,https://github.com/nexcess/magento-sentry-two-factor-authentication/pull/28/commits/c34a60fe013c1d0ea77fba74ce705dcec5d95cba,https://github.com/nexcess/magento-sentry-two-factor-authentication
 IWD_All,,iwdall/adminhtml_support/send,Max Chadwick,https://www.iwdagency.com/help/getting-started/installing-iwd-all
 Made_Cache,1.5.2,/madecache/varnish/esi/,https://github.com/madepeople/Made_Cache/commit/bbea7a966cf52114337891dffe67a5af97afa34f,https://github.com/madepeople/Made_Cache
 MageStore_AffiliatePlus,4.5,,https://www.getastra.com/blog/cms/magento-module-xss-affiliate-plus-update/,https://www.magestore.com/affiliateplus.html


### PR DESCRIPTION
Added a fifth column per the readme ("URL with upgrade instructions (optional)"), and filled it with data where I could.

In cases where the extension URL was already in 'reference', I moved it into the new column.

In cases where the extension doesn't appear to be available at all anymore, I put 'Abandoned'.