### PR TITLE
Added magerun plugin `dev:module:security`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,37 @@ The list contains these columns:
 
 Magento is an attractive target for payment skimmers and the number of attacks has increased steadily since 2015. In 2018, attackers are shifting from Magento core exploits (eg, Shoplift, brute force attacks on admin passwords) to [3rd party software components](https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/). This poses a practical problem: there is no central place where one can (programmatically) find out whether a particular module version has known security issues. This repository solves that!
 
+# Usage
+You can quickly scan your site against this blacklist using a Magerun module or a single-line command. Both require command line or SSH access to the server. Magerun is recommended as it can be easily scheduled or used on an ongoing basis, and provides better output. Both approaches load the latest vulnerability data on every run.
+
+### Magerun module (recommended)
+
+1. [Install n98-magerun](https://github.com/netz98/n98-magerun)
+2. Install the Magento1 Module Blacklist plugin:
+```
+mkdir -p ~/.n98-magerun/modules
+cd ~/.n98-magerun/modules
+git clone https://github.com/gwillem/magento1-module-blacklist.git
+```
+3. Scan your Magento install:
+```
+n98-magerun.phar dev:module:security
+```
+
+You can also use the `-q` flag to limit output to findings only.
+```
+n98-magerun.phar dev:module:security -q
+```
+
+### Quick run
+
+To quickly check a Magento installation for vulnerable modules, run this command in SSH **at your Magento site root**:
+
+    php -r "require_once('app/Mage.php');Mage::app();$config=Mage::getConfig()->getNode()->modules;$found=array();$list=fopen('https://raw.githubusercontent.com/gwillem/magento1-module-blacklist/master/magento1-vulnerable-extensions.csv','r');while($list&&list($name,$version)=list($row['module'],$row['fixed_in'],,$row['reference'],$row['update'])=fgetcsv($list)){if(isset($name,$version,$config->{$name},$config->{$name}->version)&&(empty($version)||version_compare($config->{$name}->version,$version,'<'))){$found[]=$row;}}if($found){echo 'Found possible vulnerable modules: '.print_r($found,1);}else{echo 'No known vulnerable modules detected.';}"
+
 # Todo
 
 - [ ] Import past security incidents
-- [ ] Release n98-magerun module that checks for insecure modules, similar to the module version checker @ http://tools.hypernode.com/
 - [ ] Integrate with Ext-DN
 
 # Contributing

--- a/n98-magerun.yaml
+++ b/n98-magerun.yaml
@@ -1,0 +1,6 @@
+autoloaders:
+  ModuleBlacklist: %module%/src
+
+commands:
+  customCommands:
+    - ModuleBlacklist\Magerun\SecurityScanCommand

--- a/src/ModuleBlacklist/Magerun/SecurityScanCommand.php
+++ b/src/ModuleBlacklist/Magerun/SecurityScanCommand.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Magerun plugin: Scan the current Magento 1 installation for known vulnerable modules.
+ *
+ * Execute as:
+ *  n98-magerun.phar dev:module:security [-q]
+ *
+ * @see    https://github.com/gwillem/magento1-module-blacklist
+ * @author Ryan Hoerr <rhoerr@gmail.com>
+ */
+
+namespace ModuleBlacklist\Magerun;
+
+use N98\Magento\Command\AbstractMagentoCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SecurityScanCommand extends AbstractMagentoCommand
+{
+    const BLACKLIST_URL = 'https://raw.githubusercontent.com/gwillem/magento1-module-blacklist/master/magento1-vulnerable-extensions.csv';
+    
+    /**
+     * @return void
+     */
+    protected function configure()
+    {
+        $this->setName('dev:module:security')
+             ->setDescription('Check installed modules for known vulnerabilities');
+    }
+
+   /**
+    * @param \Symfony\Component\Console\Input\InputInterface $input
+    * @param \Symfony\Component\Console\Output\OutputInterface $output
+    * @return void
+    */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->detectMagento($output);
+        
+        if ($this->initMagento()) {
+            $modules   = \Mage::getConfig()->getNode()->modules;
+            $blacklist = fopen(static::BLACKLIST_URL, 'r');
+            $hitCount  = 0;
+            
+            if ($blacklist === false) {
+                $output->writeln(
+                    '<error>Unable to load the latest vulnerability data.</error>',
+                    OutputInterface::VERBOSITY_QUIET
+                );
+                return;
+            }
+            
+            while ($row = fgetcsv($blacklist)) {
+                $name      = $row[0];
+                $fixedIn   = $row[1];
+                $credit    = $row[3];
+                $updateUrl = $row[4];
+                $version   = isset($modules->{$name}->version) ? $modules->{$name}->version : null;
+                
+                if ($version !== null
+                    && (empty($fixedIn) || version_compare($modules->{$name}->version, $fixedIn, '<'))) {
+                    $output->writeln(
+                        sprintf(
+                            '<error>Vulnerable module found: %s%s</error>',
+                            $name,
+                            $output->isQuiet() && !empty($fixedIn) ? sprintf(' (%s < %s)', $version, $fixedIn) : ''
+                        ),
+                        OutputInterface::VERBOSITY_QUIET
+                    );
+                    
+                    $output->writeln(sprintf('<comment>Installed:</comment>  %s', $modules->{$name}->version));
+                    $output->writeln(sprintf('<comment>Fixed In:</comment>   %s', $fixedIn ?: '(none)'));
+                    
+                    if (!empty($updateUrl)) {
+                        $output->writeln(sprintf('<comment>Update URL:</comment> %s', $updateUrl));
+                    }
+                    
+                    if (!empty($credit)) {
+                        $output->writeln(sprintf('<comment>Credit:</comment>     %s', $credit));
+                    }
+                    
+                    $output->writeln('');
+                    
+                    $hitCount++;
+                }
+            }
+
+            if ($hitCount === 0) {
+                $output->writeln('No known vulnerable modules detected.');
+            }
+        }
+    }
+}

--- a/src/ModuleBlacklist/Magerun/standalone-module-scan.php
+++ b/src/ModuleBlacklist/Magerun/standalone-module-scan.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Standalone Magento module blacklist check script. This is equivalent to the single-line command in the readme.
+ *
+ * Don't use this script. Follow the README instructions.
+ *
+ * @see    https://github.com/gwillem/magento1-module-blacklist
+ * @author Ryan Hoerr <rhoerr@gmail.com>
+ */
+
+require_once('app/Mage.php');
+Mage::app();
+
+$config = Mage::getConfig()->getNode()->modules;
+$found = array();
+$list = fopen('https://raw.githubusercontent.com/gwillem/magento1-module-blacklist/master/magento1-vulnerable-extensions.csv', 'r');
+while ($list && list($name, $version) = list($row['module'], $row['fixed_in'], , $row['reference'], $row['update']) = fgetcsv($list)) {
+	if (isset($name, $version, $config->{$name}->version)
+		&& (empty($version) || version_compare($config->{$name}->version, $version, '<'))) {
+		$found[] = $row;
+	}
+}
+
+if ($found) {
+	echo 'Found possible vulnerable modules: '.print_r($found, 1);
+} else {
+	echo 'No known vulnerable modules detected.';
+}


### PR DESCRIPTION
Here's a tentative magerun plugin per https://github.com/gwillem/magento1-module-blacklist/issues/4. I wasn't sure the best file structure so I followed what other plugins seem to use.

The plugin supports two output modes. Default is full verbosity, which will output all data or "No known vulnerable modules detected." if clean.

![2019-01-26_144257](https://user-images.githubusercontent.com/13335952/51792395-43e22200-217e-11e9-8b9b-dbdc0d086bc7.png)

Quiet `-q` will output matches only, with no message on a clean scan.

![2019-01-26_144311](https://user-images.githubusercontent.com/13335952/51792402-565c5b80-217e-11e9-8050-dcee827630f9.png)

I also included the single-line command version as formatted script and in the readme. Simpler output, no magerun dependency.

We'll need a public and static URL for the CSV before this is ready. I'm not sure what you (@gwillem) have in mind for that. The current URL will throw an auth failure.