### PR TITLE
Dealer4dealer Xcore >= 1.1.0 in M1

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -45,6 +45,7 @@ CommerceExtensions_Wishlistimportexport,0.3.0,/wishlistimportexport/,https://www
 CommerceLab_News,,/clnews/,https://www.magecloud.net/marketplace/extension/news-by-commercelab/,
 CommerceLab_GreatNews,,/clnews/,https://www.magecloud.net/marketplace/extension/news-by-commercelab/,
 CommerceThemes_GuestToReg,,/GuestToReg/index/post/,https://twitter.com/gwillem/status/1065986386795380736,Abandoned
+dealer4dealer_xcore,,/api/sales/order/info,https://github.com/dealer4dealer/magento1-soapapi/pull/35,https://github.com/dealer4dealer/magento1-soapapi/pull/35
 EM_Ajaxcart,,,https://magento.com/security/vulnerabilities/sql-injection-vulnerability,https://www.emthemes.com/em-ajaxcart.html
 EM_AjaxProducts,1.0.0,/ajaxproducts/index/index,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://www.emthemes.com/free-magento-extensions/ajax-products-load-more-magento-extension.html
 EM_Multideal,,/multidealpro/index/edit/,https://gwillem.gitlab.io/2018/10/23/magecart-extension-0days/,https://www.emthemes.com/em-multideal.html


### PR DESCRIPTION
This problem is since 1.1.0 and is sitting quietly for 3 years...

Via Magento 1 System / Configuration, it's possible to inject modified serialized data and when the next API call will be made,  the unserialize function will be executed on a specially crafted string, this will make a shop vulnerable for PHP Object Injection.

API Endpoint are protected with a token, but hence you are already in Admin, this is a possibility to get full control over the Magento shop