### PR TITLE
Add Mageplaza Layered Navigation XSS Vulnerability 

### DIFF
--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -20,6 +20,8 @@ Lof_ChatSystem,1.0.3,,https://web.archive.org/web/20210320101040/https://another
 Lof_Formbuilder,1.1.2,,https://web.archive.org/web/20210320101040/https://anothernetsecblog.com/magento-2-extension-security/,
 Magefan_LoginAsCustomer,2.2.3,,https://github.com/magefan/module-login-as-customer/commit/1da0bcef0f811a27aa1783c1e9e3595aa065f4e9,https://github.com/magefan/module-login-as-customer/releases/tag/2.2.3
 Mageplaza_LayeredNavigation,2.3.6,,https://www.mageplaza.com/releases/layered-navigation/,https://www.mageplaza.com/magento-2-layered-navigation-extension/
+Mageplaza_LayeredNavigation,2.5.2,,https://www.mageplaza.com/releases/layered-navigation/,https://www.mageplaza.com/magento-2-layered-navigation-extension/
+Mageplaza_LayeredNavigation,4.1.2,,https://www.mageplaza.com/releases/layered-navigation/,https://www.mageplaza.com/magento-2-layered-navigation-extension/
 Magestore_Storelocator,1.0.2,,,https://blog.magestore.com/store-locator-extension-patch/
 Magestore_Storepickup,1.2.1,,,https://blog.magestore.com/store-locator-extension-patch/
 Mirasvit_Blog,1.0.21,,,https://github.com/mirasvit/module-blog


### PR DESCRIPTION
As per: https://www.mageplaza.com/releases/layered-navigation/

Do we have a way to split module versions? Mageplaza are currently maintaining a Magento 2.3 and a Magento 2.4 version of this module which have different release lines e.g. 2.3 = 2.x, 2.4 = 4.x

I've added both versions in this PR but appreciate this will likely cause issues e.g. a person on Magento 2.3 with v2.5.2 of Layered Navigation will probably get an alert to upgrade to 4.1.2 despite already having the XSS patch applied.
