### PR TITLE
Revert "Fishpig appears hacked (#98)"

### DIFF
--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -14,11 +14,6 @@ BlueFormBuilder_Core,,,https://web.archive.org/web/20210320101040/https://anothe
 Campaigner_Integration,,,Max Chadwick,
 Cardgate_Payment,2.0.31,/cardgate/payment/callback,https://github.com/cardgate/magento2/issues/54,https://github.com/cardgate/magento2/releases
 Customweb_InternetkasseCw,4.0.339,,https://www.sellxed.com/shop/en/eur/software/changelog/index/magento-s-internetkasse-zahlungs-extension.html,
-FishPig_NoBots,,,https://sansec.io/research/rekoobe-fishpig-magento,https://fishpig.co.uk/magento/extensions/
-FishPig_WordPress_ACF,,,https://sansec.io/research/rekoobe-fishpig-magento,https://fishpig.co.uk/magento/extensions/
-FishPig_WordPress_Multisite,,,https://sansec.io/research/rekoobe-fishpig-magento,https://fishpig.co.uk/magento/extensions/
-FishPig_WordPress_PluginShortcodeWidget,,,https://sansec.io/research/rekoobe-fishpig-magento,https://fishpig.co.uk/magento/extensions/
-FishPig_WordPress_RelatedProducts,,,https://sansec.io/research/rekoobe-fishpig-magento,https://fishpig.co.uk/magento/extensions/
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
 Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933
 Klaviyo_Reclaim,3.0.0,reclaim/checkout/cart,https://gist.github.com/JeroenBoersma/f5864a45e3df63b198a57abdff366df2,https://github.com/klaviyo/magento2-klaviyo/releases


### PR DESCRIPTION
Reverts sansecio/magevulndb#98

Reverting, FishPig has not released new version numbers, as the malware injection happened in its deployment pipeline.
This means that we cannot use version numbers to determine malicious code.