### PR TITLE
add AHT_Advancedmedia

### DIFF
--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -1,6 +1,6 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
 Addonline_SoColissimo,2.2.1,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
-AHT_Advancedmedia,,/advancedmedia/index/upload/,,https://github.com/sansecio/magevulndb/pull/100
+AHT_Advancedmedia,,/advancedmedia/index/upload/,https://github.com/sansecio/magevulndb/pull/100,
 Amasty_Acart,1.17.4,,,https://amasty.com/magento-abandoned-cart-email.html
 Amasty_Blog,2.3.4,,,https://amasty.com/magento-blog-pro.html
 Amasty_Customform,1.7.3,,,https://amasty.com/magento-form-builder.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -1,5 +1,6 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
 Addonline_SoColissimo,2.2.1,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
+AHT_Advancedmedia,,/advancedmedia/index/upload/,,
 Amasty_Acart,1.17.4,,,https://amasty.com/magento-abandoned-cart-email.html
 Amasty_Blog,2.3.4,,,https://amasty.com/magento-blog-pro.html
 Amasty_Customform,1.7.3,,,https://amasty.com/magento-form-builder.html

--- a/magento1-vulnerable-extensions.csv
+++ b/magento1-vulnerable-extensions.csv
@@ -1,6 +1,6 @@
 Name,Fixed in,Relevant URI,Reference,Update URL
 Addonline_SoColissimo,2.2.1,/socolissimo/ajax/getcitynamebyzipcode/,https://twitter.com/gwillem/status/1121397274041638913,http://www.modules-ecommerce.fr
-AHT_Advancedmedia,,/advancedmedia/index/upload/,,
+AHT_Advancedmedia,,/advancedmedia/index/upload/,,https://github.com/sansecio/magevulndb/pull/100
 Amasty_Acart,1.17.4,,,https://amasty.com/magento-abandoned-cart-email.html
 Amasty_Blog,2.3.4,,,https://amasty.com/magento-blog-pro.html
 Amasty_Customform,1.7.3,,,https://amasty.com/magento-form-builder.html


### PR DESCRIPTION
File upload to Magento1 media directory via AHT_Advancedmedia extension.
Secure version unknown. Vendor unknown.


From access logs in dfir case:
```
198.167.192.5   -  2022-10-22T16:28:19Z "POST /index.php/advancedmedia/index/upload/ HTTP/1.1" 200 62 "" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0" 0.075 0.072

198.167.192.5   -  2022-10-22T16:28:30Z "GET /media/catalog/product/a/d/adramen.php HTTP/1.1" 200 689 "" "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:104.0) Gecko/20100101 Firefox/104.0" 0.000
```
Confirmed adramen.php was php backdoor.
Was able to reproduce file upload.

Vulnerable code in `app/code/local/AHT/Advancedmedia/controllers/IndexController.php`:

```
        public function uploadAction(){
                $tempFile = $_FILES['Filedata']['tmp_name'];
                $targetPath = Mage::getBaseDir('media').'/catalog/product/';//$_SERVER['DOCUMENT_ROOT'] . $_REQUEST['folder'] . '/';
                
                $firstCharacter = substr ($_FILES['Filedata']['name'], 0, 1);
                $targetPath.=$firstCharacter;

                if(!is_dir($targetPath)){
                        mkdir($targetPath , 0777, true);
                }
                
                $secondCharacter = substr ($_FILES['Filedata']['name'], 1, 1);
                $targetPath.='/'.$secondCharacter;
                
                if(!is_dir($targetPath)){
                        mkdir($targetPath , 0777, true);
                }
                $targetFile = $targetPath.'/'.$_FILES['Filedata']['name'];      
                move_uploaded_file($tempFile,$targetFile);
                $string = str_replace(Mage::getBaseDir('media'), '', $targetFile);
                
                echo str_replace('/catalog', 'catalog' ,$string);
        }
```
