### PR TITLE
update campaigner fix version

### DIFF
--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -11,7 +11,7 @@ Amasty_Storeswitcher?,1.0.13,,,https://amasty.com/store-switcher-for-magento-2.h
 AW_Blog,2.4.6,,https://ecommerce.aheadworks.com/magento-extension-updates/blog,https://ecommerce.aheadworks.com/magento-2-extensions/blog
 Bss_MultiWishlist,1.2.0,,https://xn--gran-8qa.fi/bss-multiwishlist-xss-injection/,https://bsscommerce.com/magento-2-multiple-wishlists-extension.html
 BlueFormBuilder_Core,,,https://web.archive.org/web/20210320101040/https://anothernetsecblog.com/magento-2-extension-security/,
-Campaigner_Integration,,,Max Chadwick,
+Campaigner_Integration,2.0.8,,Max Chadwick (unsafe unserialize in public controller),https://knowledge.campaigner.com/article/407-magento-extensions
 Cardgate_Payment,2.0.31,/cardgate/payment/callback,https://github.com/cardgate/magento2/issues/54,https://github.com/cardgate/magento2/releases
 Customweb_InternetkasseCw,4.0.339,,https://www.sellxed.com/shop/en/eur/software/changelog/index/magento-s-internetkasse-zahlungs-extension.html,
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,


### PR DESCRIPTION
Unfortunately Campaigner doesn't have release notes, so I don't know what exact version it was fixed in.

I did however check with @mpchadwick what the issue was, and it was unsafe usage of unserialize in a public controller. 
Their latest version uses json decoding instead.