### PR TITLE
Added ConnectPOS_Core module as vulnerable module.

### DIFF
--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -13,7 +13,7 @@ Bss_MultiWishlist,1.2.0,,https://xn--gran-8qa.fi/bss-multiwishlist-xss-injection
 BlueFormBuilder_Core,2.0.2,,https://web.archive.org/web/20210320101040/https://anothernetsecblog.com/magento-2-extension-security/,
 Campaigner_Integration,2.0.8,,Max Chadwick (unsafe unserialize in public controller),https://knowledge.campaigner.com/article/407-magento-extensions
 Cardgate_Payment,2.0.31,/cardgate/payment/callback,https://github.com/cardgate/magento2/issues/54,https://github.com/cardgate/magento2/releases
-ConnectPOS_Core,23.09.03,/rest/V2/connectpos,,
+ConnectPOS_Core,23.09.03,/rest/V2/connectpos,https://github.com/sansecio/magevulndb/pull/107,
 Customweb_InternetkasseCw,4.0.339,,https://www.sellxed.com/shop/en/eur/software/changelog/index/magento-s-internetkasse-zahlungs-extension.html,
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
 Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933

--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -13,7 +13,7 @@ Bss_MultiWishlist,1.2.0,,https://xn--gran-8qa.fi/bss-multiwishlist-xss-injection
 BlueFormBuilder_Core,2.0.2,,https://web.archive.org/web/20210320101040/https://anothernetsecblog.com/magento-2-extension-security/,
 Campaigner_Integration,2.0.8,,Max Chadwick (unsafe unserialize in public controller),https://knowledge.campaigner.com/article/407-magento-extensions
 Cardgate_Payment,2.0.31,/cardgate/payment/callback,https://github.com/cardgate/magento2/issues/54,https://github.com/cardgate/magento2/releases
-ConnectPOS_Core,23.09.03,/rest/V2/connectpos/*,,
+ConnectPOS_Core,23.09.03,/rest/V2/connectpos,,
 Customweb_InternetkasseCw,4.0.339,,https://www.sellxed.com/shop/en/eur/software/changelog/index/magento-s-internetkasse-zahlungs-extension.html,
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
 Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933

--- a/magento2-vulnerable-extensions.csv
+++ b/magento2-vulnerable-extensions.csv
@@ -13,6 +13,7 @@ Bss_MultiWishlist,1.2.0,,https://xn--gran-8qa.fi/bss-multiwishlist-xss-injection
 BlueFormBuilder_Core,2.0.2,,https://web.archive.org/web/20210320101040/https://anothernetsecblog.com/magento-2-extension-security/,
 Campaigner_Integration,2.0.8,,Max Chadwick (unsafe unserialize in public controller),https://knowledge.campaigner.com/article/407-magento-extensions
 Cardgate_Payment,2.0.31,/cardgate/payment/callback,https://github.com/cardgate/magento2/issues/54,https://github.com/cardgate/magento2/releases
+ConnectPOS_Core,23.09.03,/rest/V2/connectpos/*,,
 Customweb_InternetkasseCw,4.0.339,,https://www.sellxed.com/shop/en/eur/software/changelog/index/magento-s-internetkasse-zahlungs-extension.html,
 Fooman_PdfCustomiser,8.1.8,,https://twitter.com/foomanNZ/status/1118496841488748546,
 Fooman_Tcpdf,6.2.25.2,,,https://mailchi.mp/fooman/important-security-update-for-pdf-customiser-3218933


### PR DESCRIPTION
Hi there

I've never contributed here, so in case I made a mistake, let me know :)

This is about the ConnectPOS_Core module, which is part of a whole bunch of ConnectPOS suite of modules that are not available as open source. The source is hosted on github but is private.

We found out a couple of weeks ago, that the module has some REST endpoints they use for debugging, which allows them to see the following things from your Magento shop:
- the main `composer.json` file of the Magento shop
- all the version numbers of the various ConnectPOS modules
- all the files in `var/log`
- all the files in `var/report`

The big problem is that those endpoints where publicly available without any authentication.

After some back and forth with them, they fixed this in version 23.09.03 of their module, the endpoints are still there, but they now require authentication.

After looking through their git logs, those endpoints got added in version 23.01.07, so all versions between 23.01.07 and 23.09.03 are vulnerable.